### PR TITLE
Update to Arnold 5

### DIFF
--- a/cryptomatte/cryptomatte.h
+++ b/cryptomatte/cryptomatte.h
@@ -5,6 +5,7 @@
 #include <ctime>
 #include "MurmurHash3.h"
 #include <cstdio>
+#include <algorithm>
 #include <limits>
 
 #define NOMINMAX // lets you keep using std::min

--- a/cryptomatte/cryptomatte.h
+++ b/cryptomatte/cryptomatte.h
@@ -1,12 +1,13 @@
 #include <ai.h>
 #include <string>
+#include <unordered_set>
 #include <cstring>
 #include <map>
 #include <ctime>
 #include "MurmurHash3.h"
 #include <cstdio>
-#include <algorithm>
 #include <limits>
+#include <algorithm>
 
 #define NOMINMAX // lets you keep using std::min
 
@@ -99,9 +100,9 @@ Declaring user-data driven Cryptomattes:
 #define MAX_USER_CRYPTOMATTES 16
 
 // User data names
-#define CRYPTO_ASSET_UDATA "crypto_asset"
-#define CRYPTO_OBJECT_UDATA "crypto_object"
-#define CRYPTO_MATERIAL_UDATA "crypto_material"
+static const AtString CRYPTO_ASSET_UDATA("crypto_asset");
+static const AtString CRYPTO_OBJECT_UDATA("crypto_object");
+static const AtString CRYPTO_MATERIAL_UDATA("crypto_material");
 
 // Arnold options parameters
 //      For user cryptomattes
@@ -137,13 +138,13 @@ unsigned char g_pointcloud_instance_verbosity = 0;  // to do: remove this.
 #endif
 
 struct CACHE_ALIGN CryptomatteCache {
-    AtNode * object;        //       8 bytes
-    AtColor nsp_hash_clr;   //      16 bytes
-    AtColor obj_hash_clr;   //      16 bytes
-    AtNode * shader_object; //       8 bytes
-    AtColor mat_hash_clr;   //      16 bytes
-                            //  +_______
-                            //      64 bytes
+    AtNode * object;        
+    AtRGB nsp_hash_clr;   
+    AtRGB obj_hash_clr;   
+    AtNode * shader_object; 
+    AtRGB mat_hash_clr;   
+
+
     CryptomatteCache() {
         this->object = NULL;
         this->nsp_hash_clr = AI_RGB_BLACK;
@@ -338,7 +339,7 @@ float hash_to_float(uint32_t hash) {
 }
 
 
-void hash_name_rgb(const char * name, AtColor* out_color) {
+void hash_name_rgb(const char * name, AtRGB* out_color) {
     // This puts the float ID into the red channel, and the human-readable
     // versions into the G and B channels. 
     uint32_t m3hash = 0;
@@ -349,7 +350,7 @@ void hash_name_rgb(const char * name, AtColor* out_color) {
 }
 
 
-const char* get_user_data(AtShaderGlobals * sg, AtNode * node, const char* user_data_name, bool *cachable) {
+AtString get_user_data(AtShaderGlobals * sg, AtNode * node, AtString user_data_name, bool *cachable) {
     // returns the string if the parameter is usable, modifies cachable
     const AtUserParamEntry* pentry = AiNodeLookUpUserParameter(node, user_data_name);
     if (pentry) {
@@ -361,13 +362,13 @@ const char* get_user_data(AtShaderGlobals * sg, AtNode * node, const char* user_
         // this is intentionally outside the if (pentry) block. 
         // With user data declared on ginstances and such, no pentry
         // is aquirable but AiUDataGetStr still works. 
-        const char * udata_value = NULL;
-        if (AiUDataGetStr(user_data_name, &udata_value)) {
+        AtString udata_value;
+        if (AiUDataGetStr(user_data_name, udata_value)) {
             *cachable = false;
             return udata_value;
         }
     }
-    return NULL;
+    return AtString();
 }
 
 
@@ -379,8 +380,8 @@ bool get_object_names(AtShaderGlobals *sg, AtNode *node, bool strip_obj_ns,
     bool obj_has_override = string_has_content(obj_override);
     bool cachable = !obj_has_override && !nsp_has_override;
 
-    const char *nsp_user_data = nsp_has_override ? NULL : get_user_data(sg, node, CRYPTO_ASSET_UDATA, &cachable);
-    const char *obj_user_data = obj_has_override ? NULL : get_user_data(sg, node, CRYPTO_OBJECT_UDATA, &cachable);
+    AtString nsp_user_data = nsp_has_override ? AtString() : get_user_data(sg, node, CRYPTO_ASSET_UDATA, &cachable);
+    AtString obj_user_data = obj_has_override ? AtString() : get_user_data(sg, node, CRYPTO_OBJECT_UDATA, &cachable);
 
     bool need_nsp_name = !nsp_has_override && !nsp_user_data;        
     bool need_obj_name = !obj_has_override && !obj_user_data;
@@ -409,7 +410,7 @@ bool get_material_name(AtShaderGlobals *sg, AtNode *node, AtNode *shader, bool s
 {
     bool mat_has_override = string_has_content(mat_override);
     bool cachable = !mat_has_override; 
-    const char * mat_user_data = mat_has_override ? NULL : get_user_data(sg, node, CRYPTO_MATERIAL_UDATA, &cachable);
+    AtString mat_user_data = mat_has_override ? AtString() : get_user_data(sg, node, CRYPTO_MATERIAL_UDATA, &cachable);
 
     if (!mat_has_override)
         get_clean_material_name(AiNodeGetName(shader), mat_name_out, strip_mat_ns);
@@ -431,15 +432,15 @@ bool get_material_name(AtShaderGlobals *sg, AtNode *node, AtNode *shader, bool s
 ///////////////////////////////////////////////
 
 
-void write_array_of_AOVs(AtShaderGlobals * sg, AtArray * names, float id) {
+void write_array_of_AOVs(AtShaderGlobals * sg, AtArray * names, float id, float opacity) {
     AtVector val;
     val.x = id; 
     val.y = 0.0f;
-    val.z = AiColorToGrey(sg->out_opacity);
+    val.z = opacity;
 
-    for (AtUInt32 i=0; i < names->nelements; i++) {
-        const char * aovName = AiArrayGetStr( names, i);
-        if (!string_has_content(aovName))
+    for (uint32_t i=0; i < AiArrayGetNumElements(names); i++) {
+        AtString aovName = AiArrayGetStr( names, i);
+        if (!string_has_content(aovName)) // to do: necessary? empty atstring may be fine.. 
             return;
         AiAOVSetVec(sg, aovName, val);
     }
@@ -456,8 +457,8 @@ void write_array_of_AOVs(AtShaderGlobals * sg, AtArray * names, float id) {
 typedef std::map<std::string,float>             manf_map_t ;
 typedef std::map<std::string,float>::iterator   manf_map_it;
 
-void compute_metadata_ID(char id_buffer[8], std::string cryptomatte_name) {
-    AtColor color_hash;
+void compute_metadata_ID(char id_buffer[8], AtString cryptomatte_name) {
+    AtRGB color_hash;
     hash_name_rgb(cryptomatte_name.c_str(), &color_hash);
     uint32_t float_bits;
     std::memcpy(&float_bits, &color_hash.r, 4);
@@ -467,12 +468,12 @@ void compute_metadata_ID(char id_buffer[8], std::string cryptomatte_name) {
     strncpy(id_buffer, hex_chars, 7);
 }
 
-void write_metadata_to_driver(AtNode * driver, std::string cryptomatte_name, manf_map_t * map) {
+void write_metadata_to_driver(AtNode * driver, AtString cryptomatte_name, manf_map_t * map) {
     if (!driver)
         return;
 
     AtArray * orig_md = AiNodeGetArray( driver, "custom_attributes");
-    const AtUInt32 orig_num_entries = orig_md ? orig_md->nelements : 0;
+    const uint32_t orig_num_entries = orig_md ? AiArrayGetNumElements(orig_md) : 0;
 
     std::string metadata_hash, metadata_conv, metadata_name, metadata_manf; // the new entries
     AtArray * combined_md = AiArrayAllocate(orig_num_entries + 4, 1, AI_TYPE_STRING); //Does not need destruction
@@ -482,7 +483,7 @@ void write_metadata_to_driver(AtNode * driver, std::string cryptomatte_name, man
     compute_metadata_ID(metadata_id_buffer, cryptomatte_name);
     prefix += std::string(metadata_id_buffer) + std::string("/");
 
-    for (AtUInt32 i=0; i<orig_num_entries; i++) {
+    for (uint32_t i=0; i<orig_num_entries; i++) {
         if (prefix.compare(AiArrayGetStr(orig_md, i)) == 0) {
             AiMsgWarning("Cryptomatte: Unable to write metadata. EXR metadata key, %s, already in use.", prefix.c_str());
             return;
@@ -491,7 +492,7 @@ void write_metadata_to_driver(AtNode * driver, std::string cryptomatte_name, man
 
     metadata_hash = prefix + std::string("hash MurmurHash3_32");
     metadata_conv = prefix + std::string("conversion uint32_to_float32");
-    metadata_name = prefix + std::string("name ") + cryptomatte_name;
+    metadata_name = prefix + std::string("name ") + cryptomatte_name.c_str();
     metadata_manf = prefix + std::string("manifest ");
 
     manf_map_it map_it = map->begin();
@@ -504,7 +505,7 @@ void write_metadata_to_driver(AtNode * driver, std::string cryptomatte_name, man
     }
 
     metadata_manf.append("{");
-    for (AtUInt32 i=0; i<metadata_entries; i++) {
+    for (uint32_t i=0; i<metadata_entries; i++) {
         const char * name = map_it->first.c_str();
         float hash_value = map_it->second;
         ++map_it;
@@ -526,7 +527,7 @@ void write_metadata_to_driver(AtNode * driver, std::string cryptomatte_name, man
     }
     metadata_manf.append("}");
     
-    for (AtUInt32 i=0; i<orig_num_entries; i++) {
+    for (uint32_t i=0; i<orig_num_entries; i++) {
         AiArraySetStr(combined_md, i, AiArrayGetStr(orig_md, i));
     }
     AiArraySetStr(combined_md, orig_num_entries + 0, metadata_manf.c_str());
@@ -538,16 +539,16 @@ void write_metadata_to_driver(AtNode * driver, std::string cryptomatte_name, man
 }
 
 
-bool metadata_needed(AtNode* driver, const char* aov_name) {
-    std::string flag = std::string(CRYPTOMATTE_METADATA_SET_FLAG) + aov_name;
+bool metadata_needed(AtNode* driver, const AtString aov_name) {
+    std::string flag = std::string(CRYPTOMATTE_METADATA_SET_FLAG) + aov_name.c_str();
     return (driver && !AiNodeLookUpUserParameter(driver, flag.c_str()));
 }
 
 
-void metadata_set_unneeded(AtNode* driver, const char* aov_name) {
+void metadata_set_unneeded(AtNode* driver, const AtString aov_name) {
     if (driver == NULL)
         return;
-    std::string flag = std::string(CRYPTOMATTE_METADATA_SET_FLAG) + aov_name;
+    std::string flag = std::string(CRYPTOMATTE_METADATA_SET_FLAG) + aov_name.c_str();
     if (AiNodeLookUpUserParameter(driver, flag.c_str()) == NULL)
         AiNodeDeclare(driver, flag.c_str(), "constant BOOL");
 }
@@ -556,7 +557,7 @@ void metadata_set_unneeded(AtNode* driver, const char* aov_name) {
 void add_hash_to_map(const char * c_str, manf_map_t * md_map) {
     if (!string_has_content(c_str))
         return;
-    AtColor hash;
+    AtRGB hash;
     std::string name_string = std::string(c_str);
     if (md_map->count(name_string) == 0) {
         hash_name_rgb(c_str, &hash);
@@ -577,7 +578,7 @@ void build_user_metadata(AtArray * uc_info, AtArray* drivers) {
     AtArray * uc_src_array = AiArrayGetArray(uc_info, 1);
 
     bool do_anything = false;
-    for (AtUInt32 i=0; i<drivers->nelements; i++) {
+    for (uint32_t i=0; i<AiArrayGetNumElements(drivers); i++) {
         AtNode *driver = static_cast<AtNode*>(AiArrayGetPtr(drivers, i));
         if (driver == NULL) {
             do_metadata[i] = false;
@@ -593,7 +594,7 @@ void build_user_metadata(AtArray * uc_info, AtArray* drivers) {
     AtNodeIterator * shape_iterator = AiUniverseGetNodeIterator(AI_NODE_SHAPE);
     while (!AiNodeIteratorFinished(shape_iterator)) {
         AtNode *node = AiNodeIteratorGetNext(shape_iterator);
-        for (AtUInt32 i=0; i<drivers->nelements; i++) {
+        for (uint32_t i=0; i<AiArrayGetNumElements(drivers); i++) {
             if (!do_metadata[i])
                 continue;
             const char * user_data_name = AiArrayGetStr(uc_src_array, i);
@@ -607,7 +608,7 @@ void build_user_metadata(AtArray * uc_info, AtArray* drivers) {
             } else {
                 AtArray * values = AiNodeGetArray(node, user_data_name);
                 if (values != NULL) {
-                    for (AtUInt32 ai=0; ai<values->nelements; ai++)
+                    for (uint32_t ai=0; ai<AiArrayGetNumElements(values); ai++)
                         add_hash_to_map(AiArrayGetStr(values, ai), &map_md_user[i]);
                 }
             }
@@ -615,12 +616,12 @@ void build_user_metadata(AtArray * uc_info, AtArray* drivers) {
     }
     AiNodeIteratorDestroy(shape_iterator);
 
-    for (AtUInt32 i=0; i<drivers->nelements; i++) {
+    for (uint32_t i=0; i<AiArrayGetNumElements(drivers); i++) {
         if (!do_metadata[i])
             continue;
         
         AtNode *driver = static_cast<AtNode*>(AiArrayGetPtr(drivers, i));
-        const char *aov_name = AiArrayGetStr(uc_aov_array, i);
+        AtString aov_name = AiArrayGetStr(uc_aov_array, i);
         metadata_set_unneeded(driver, aov_name);
         write_metadata_to_driver(driver, aov_name, &map_md_user[i]);
     }
@@ -633,18 +634,18 @@ bool node_param_is_string(AtNode * node, const char* param_name) {
 }
 
 void build_standard_metadata(AtNode* driver_asset, AtNode* driver_object, AtNode* driver_material, 
-                             std::string aov_asset, std::string aov_object, std::string aov_material, 
+                             AtString aov_asset, AtString aov_object, AtString aov_material, 
                              bool strip_obj_ns, bool strip_mat_ns) 
 {
     const clock_t metadata_start_time = clock();
 
-    const bool do_md_asset = metadata_needed(driver_asset, aov_asset.c_str());
-    const bool do_md_object = metadata_needed(driver_object, aov_object.c_str());
-    const bool do_md_material = metadata_needed(driver_material, aov_material.c_str());
+    const bool do_md_asset = metadata_needed(driver_asset, aov_asset);
+    const bool do_md_object = metadata_needed(driver_object, aov_object);
+    const bool do_md_material = metadata_needed(driver_material, aov_material);
 
-    metadata_set_unneeded(driver_asset, aov_asset.c_str());
-    metadata_set_unneeded(driver_object, aov_object.c_str());
-    metadata_set_unneeded(driver_material, aov_material.c_str());
+    metadata_set_unneeded(driver_asset, aov_asset);
+    metadata_set_unneeded(driver_object, aov_object);
+    metadata_set_unneeded(driver_material, aov_material);
 
     if (!do_md_asset && !do_md_object && !do_md_material)
         return;
@@ -671,7 +672,7 @@ void build_standard_metadata(AtNode* driver_asset, AtNode* driver_object, AtNode
             // Process all shaders from the objects into the manifest. 
             // This includes cluster materials.
             AtArray * shaders = AiNodeGetArray(node, "shader");
-            for (AtUInt32 i = 0; i < shaders->nelements; i++) {
+            for (uint32_t i = 0; i < AiArrayGetNumElements(shaders); i++) {
                 AtNode * shader = static_cast<AtNode*>(AiArrayGetPtr(shaders, i));
                 get_material_name(NULL, node, shader, strip_mat_ns, NULL, mat_name);
                 add_hash_to_map(mat_name, &map_md_material); 
@@ -752,7 +753,7 @@ AtArray* init_user_cryptomatte_data() {
                 AiArraySetStr(uc_src_array, 0, AiNodeGetStr(renderOptions, CRYPTO_USER_SRC_PARAM));
             }
 
-            if (!uc_aov_array || !uc_src_array || uc_aov_array->nelements != uc_src_array->nelements) {
+            if (!uc_aov_array || !uc_src_array || AiArrayGetNumElements(uc_aov_array) != AiArrayGetNumElements(uc_src_array)) {
                 if (uc_aov_array)
                     AiArrayDestroy(uc_aov_array);
                 if (uc_src_array)
@@ -760,10 +761,10 @@ AtArray* init_user_cryptomatte_data() {
                 uc_aov_array = NULL;
                 uc_src_array = NULL;
             } else {
-                const int user_aov_num = std::min(uc_aov_array->nelements, (AtUInt32) MAX_USER_CRYPTOMATTES);
-                if (user_aov_num < (int) uc_aov_array->nelements) {
+                const int user_aov_num = std::min(AiArrayGetNumElements(uc_aov_array), (uint32_t) MAX_USER_CRYPTOMATTES);
+                if (user_aov_num < (int) AiArrayGetNumElements(uc_aov_array)) {
                     AiMsgWarning("Cryptomatte: Maximum number of user cryptomattes is %d, removing %d", 
-                        MAX_USER_CRYPTOMATTES, uc_aov_array->nelements - user_aov_num);
+                        MAX_USER_CRYPTOMATTES, AiArrayGetNumElements(uc_aov_array) - user_aov_num);
                 }
                 uc_info = AiArrayAllocate(2+user_aov_num, 1, AI_TYPE_ARRAY);
                 AiArraySetArray(uc_info, 0, uc_aov_array);
@@ -800,7 +801,7 @@ struct CryptomatteGlobals {
 
         AtNode * options = AiUniverseGetOptions();
         AtNode * controller = static_cast<AtNode*>( AiNodeGetPtr(options, "background") );
-        if (controller && AiNodeIs(controller, "uBasic_controller")) {
+        if (controller && AiNodeIs(controller, AtString("uBasic_controller"))) {
             // this is legacy Psyop stuff. Sorry. 
             strip_mat_ns = AiNodeGetBool(controller, "strip_material_namespaces");
             if (AiNodeGetBool(controller, "override_cryptomatte")) {
@@ -851,9 +852,9 @@ struct CryptomatteGlobals {
 
 
 struct CryptomatteData {
-    std::string aov_cryptoasset;
-    std::string aov_cryptoobject;
-    std::string aov_cryptomaterial;
+    AtString aov_cryptoasset;
+    AtString aov_cryptoobject;
+    AtString aov_cryptomaterial;
     AtArray * aovArray_cryptoasset;
     AtArray * aovArray_cryptoobject;
     AtArray * aovArray_cryptomaterial;
@@ -870,9 +871,9 @@ public:
     }
 
     void setup_all(const char* aov_cryptoasset, const char* aov_cryptoobject, const char* aov_cryptomaterial) {
-        this->aov_cryptoasset = std::string(aov_cryptoasset);
-        this->aov_cryptoobject = std::string(aov_cryptoobject);
-        this->aov_cryptomaterial = std::string(aov_cryptomaterial);
+        this->aov_cryptoasset = AtString(aov_cryptoasset);
+        this->aov_cryptoobject = AtString(aov_cryptoobject);
+        this->aov_cryptomaterial = AtString(aov_cryptomaterial);
 
         this->destroy_arrays();
 
@@ -886,21 +887,21 @@ public:
     //     ReleaseMutex( g_hIOMutex);
     // }
 
-    void do_cryptomattes(AtShaderGlobals *sg, AtNode * node, int p_override_asset, int p_override_object, int p_override_material ) {
+    void do_cryptomattes(AtShaderGlobals *sg, AtNode * node, int p_override_asset, int p_override_object, int p_override_material, float opacity ) {
         if (sg->Rt & AI_RAY_CAMERA) {
-            this->do_standard_cryptomattes(sg, node, p_override_asset, p_override_object, p_override_material);
-            this->do_user_cryptomattes(sg);
+            this->do_standard_cryptomattes(sg, node, p_override_asset, p_override_object, p_override_material, opacity);
+            this->do_user_cryptomattes(sg, opacity);
         }
     }
 
 private:
-    void do_standard_cryptomattes(AtShaderGlobals *sg, AtNode * node, int p_override_asset, int p_override_object, int p_override_material ) {
-        if (!AiAOVEnabled(this->aov_cryptoasset.c_str(), AI_TYPE_RGB)
-            && !AiAOVEnabled(this->aov_cryptoobject.c_str(), AI_TYPE_RGB)
-            && !AiAOVEnabled(this->aov_cryptomaterial.c_str(), AI_TYPE_RGB)) {
+    void do_standard_cryptomattes(AtShaderGlobals *sg, AtNode * node, int p_override_asset, int p_override_object, int p_override_material, float opacity ) {
+        if (!AiAOVEnabled(this->aov_cryptoasset, AI_TYPE_RGB)
+            && !AiAOVEnabled(this->aov_cryptoobject, AI_TYPE_RGB)
+            && !AiAOVEnabled(this->aov_cryptomaterial, AI_TYPE_RGB)) {
             return;
         }
-        AtColor nsp_hash_clr, obj_hash_clr, mat_hash_clr;
+        AtRGB nsp_hash_clr, obj_hash_clr, mat_hash_clr;
 
         const char * nsp_override = (p_override_asset > -1) ? AiShaderEvalParamStr(p_override_asset) : "";
         const char * obj_override = (p_override_object > -1) ? AiShaderEvalParamStr(p_override_object) : "";
@@ -908,49 +909,49 @@ private:
 
         this->hash_object_rgb(sg, &nsp_hash_clr, &obj_hash_clr, &mat_hash_clr, nsp_override, obj_override, mat_override);
 
-        if (AiAOVEnabled(this->aov_cryptoasset.c_str(), AI_TYPE_VECTOR))
-            write_array_of_AOVs(sg, this->aovArray_cryptoasset, nsp_hash_clr.r);
-        if (AiAOVEnabled(this->aov_cryptoobject.c_str(), AI_TYPE_VECTOR))
-            write_array_of_AOVs(sg, this->aovArray_cryptoobject, obj_hash_clr.r);
-        if (AiAOVEnabled(this->aov_cryptomaterial.c_str(), AI_TYPE_VECTOR))
-            write_array_of_AOVs(sg, this->aovArray_cryptomaterial, mat_hash_clr.r);
+        if (AiAOVEnabled(this->aov_cryptoasset, AI_TYPE_VECTOR))
+            write_array_of_AOVs(sg, this->aovArray_cryptoasset, nsp_hash_clr.r, opacity);
+        if (AiAOVEnabled(this->aov_cryptoobject, AI_TYPE_VECTOR))
+            write_array_of_AOVs(sg, this->aovArray_cryptoobject, obj_hash_clr.r, opacity);
+        if (AiAOVEnabled(this->aov_cryptomaterial, AI_TYPE_VECTOR))
+            write_array_of_AOVs(sg, this->aovArray_cryptomaterial, mat_hash_clr.r, opacity);
         
         nsp_hash_clr.r = 0.0f;
         obj_hash_clr.r = 0.0f;
         mat_hash_clr.r = 0.0f;
 
-        AiAOVSetRGBA(sg, this->aov_cryptoasset.c_str(), AiRGBtoRGBA( nsp_hash_clr ));      
-        AiAOVSetRGBA(sg, this->aov_cryptoobject.c_str(), AiRGBtoRGBA( obj_hash_clr ));
-        AiAOVSetRGBA(sg, this->aov_cryptomaterial.c_str(), AiRGBtoRGBA( mat_hash_clr ));
+        AiAOVSetRGBA(sg, this->aov_cryptoasset, nsp_hash_clr);      
+        AiAOVSetRGBA(sg, this->aov_cryptoobject, obj_hash_clr);
+        AiAOVSetRGBA(sg, this->aov_cryptomaterial, mat_hash_clr);
     }
 
-    void do_user_cryptomattes(AtShaderGlobals * sg) {
+    void do_user_cryptomattes(AtShaderGlobals * sg, float opacity ) {
         if (this->user_cryptomatte_info == NULL)
             return;
 
         AtArray* uc_aov_array = AiArrayGetArray(this->user_cryptomatte_info, 0);
         AtArray* uc_src_array = AiArrayGetArray(this->user_cryptomatte_info, 1);
 
-        for (AtUInt32 uc_index=2; uc_index<this->user_cryptomatte_info->nelements; uc_index++) {
+        for (uint32_t uc_index=2; uc_index<AiArrayGetNumElements(this->user_cryptomatte_info); uc_index++) {
             AtArray * aovArray = AiArrayGetArray(this->user_cryptomatte_info, uc_index);
             if (aovArray != NULL) {
-                AtUInt32 i = uc_index-2;
-                const char * aov_name = AiArrayGetStr(uc_aov_array, i);
-                const char * src_data_name = AiArrayGetStr(uc_src_array, i);
+                uint32_t i = uc_index-2;
+                AtString aov_name = AiArrayGetStr(uc_aov_array, i);
+                AtString src_data_name = AiArrayGetStr(uc_src_array, i);
+                AtRGB hash;
+                AtString result;
 
-                AtColor hash;
-                const char* result = NULL;
-                AiUDataGetStr(src_data_name, &result);
-                if (string_has_content(result)) {
-                    hash_name_rgb(result, &hash);
-                    write_array_of_AOVs(sg, aovArray, hash.r);
-                    AiAOVSetRGBA(sg, aov_name, AiRGBtoRGBA( hash ));
+                AiUDataGetStr(src_data_name, result);
+                if (string_has_content(result.c_str())) {
+                    hash_name_rgb(result.c_str(), &hash);
+                    write_array_of_AOVs(sg, aovArray, hash.r, opacity);
+                    AiAOVSetRGBA(sg, aov_name, hash);
                 }
             }
         }
     }
 
-    void hash_object_rgb(AtShaderGlobals* sg, AtColor * nsp_hash_clr, AtColor * obj_hash_clr, AtColor * mat_hash_clr, 
+    void hash_object_rgb(AtShaderGlobals* sg, AtRGB * nsp_hash_clr, AtRGB * obj_hash_clr, AtRGB * mat_hash_clr, 
                          const char * nsp_override, const char * obj_override, const char * mat_override) 
     {
         if (CRYPTOMATTE_CACHE[sg->tid].object == sg->Op) {
@@ -977,7 +978,7 @@ private:
             bool cachable = true;
             AtArray * shaders = AiNodeGetArray(sg->Op, "shader");
             AtNode *shader = NULL;
-            if (shaders->nelements == 1) {
+            if (AiArrayGetNumElements(shaders) == 1) {
                 // use whatever is assigned, not whatever is currently evaluating
                 // this will match the manifest
                 shader = static_cast<AtNode*>(AiArrayGetPtr(shaders, 0));
@@ -1013,9 +1014,9 @@ private:
         if (this->user_cryptomatte_info != NULL) {
             uc_aov_array = AiArrayGetArray(this->user_cryptomatte_info, 0);
             uc_src_array = AiArrayGetArray(this->user_cryptomatte_info, 1);
-            tmp_uc_drivers = AiArrayAllocate(uc_aov_array->nelements, 1, AI_TYPE_NODE); // destroyed later
+            tmp_uc_drivers = AiArrayAllocate(AiArrayGetNumElements(uc_aov_array), 1, AI_TYPE_NODE); // destroyed later
 
-            num_cryptomatte_AOVs += (this->user_cryptomatte_info)->nelements - 2;
+            num_cryptomatte_AOVs += AiArrayGetNumElements(this->user_cryptomatte_info) - 2;
         }
 
         this->aovArray_cryptoasset = AiArrayAllocate(this->globals.aov_depth, 1, AI_TYPE_STRING);
@@ -1030,7 +1031,7 @@ private:
         AtArray * tmp_new_outputs = AiArrayAllocate(num_cryptomatte_AOVs * this->globals.aov_depth, 1, AI_TYPE_STRING); // destroyed later
         int new_output_num = 0;
 
-        for (AtUInt32 i=0; i < outputs->nelements; i++) {
+        for (uint32_t i=0; i < AiArrayGetNumElements(outputs); i++) {
             const char * output_string = AiArrayGetStr( outputs, i);
             size_t output_string_chars = strlen(output_string);
             char temp_string[MAX_STRING_LENGTH * 8]; 
@@ -1065,7 +1066,7 @@ private:
                 driver = AiNodeLookUpByName(driver_name);
                 driver_cryptoMaterial = driver;
             } else if (this->user_cryptomatte_info != NULL) {
-                for (AtUInt32 j=0; j < uc_aov_array->nelements; j++) {
+                for (uint32_t j=0; j < AiArrayGetNumElements(uc_aov_array); j++) {
                     const char * user_aov_name = AiArrayGetStr(uc_aov_array, j);
                     if (strcmp(aov_name, user_aov_name) == 0) {
                         cryptoAOVs = AiArrayAllocate(MAX_CRYPTOMATTE_DEPTH, 1, AI_TYPE_STRING); // will be destroyed when cryptomatteData is
@@ -1082,15 +1083,15 @@ private:
         }
 
         if (new_output_num > 0) {
-            int total_outputs = outputs->nelements + new_output_num;
+            int total_outputs = AiArrayGetNumElements(outputs) + new_output_num;
             AtArray * final_outputs = AiArrayAllocate(total_outputs, 1, AI_TYPE_STRING); // Does not need destruction
-            for (AtUInt32 i=0; i < outputs->nelements; i++) {
+            for (uint32_t i=0; i < AiArrayGetNumElements(outputs); i++) {
                 // Iterate through old outputs and add them
                 AiArraySetStr(final_outputs, i, AiArrayGetStr( outputs, i));
             }
             for (int i=0; i < new_output_num; i++)  {
                 // Iterate through new outputs and add them
-                AiArraySetStr(final_outputs, i + outputs->nelements, AiArrayGetStr( tmp_new_outputs, i));
+                AiArraySetStr(final_outputs, i + AiArrayGetNumElements(outputs), AiArrayGetStr( tmp_new_outputs, i));
             }
             AiNodeSetArray(renderOptions, "outputs", final_outputs );
         }
@@ -1110,7 +1111,7 @@ private:
         // helper for setup_cryptomatte_nodes. Populates cryptoAOVs and returns the number of new outputs created. 
         int new_ouputs = 0;
 
-        if (!AiNodeIs(driver, "driver_exr")) {
+        if (!AiNodeIs(driver, AtString("driver_exr"))) {
             AiMsgWarning("Cryptomatte Error: Can only write Cryptomatte to EXR files.");
             return new_ouputs;
         }
@@ -1149,6 +1150,12 @@ private:
         
         AiAOVRegister(aov_name, AI_TYPE_RGB, AI_AOV_BLEND_OPACITY);
 
+        AtArray *outputs = AiNodeGetArray( AiUniverseGetOptions(), "outputs");
+        
+        std::unordered_set<std::string> outputSet;
+        for (int i=0; i < AiArrayGetNumElements(outputs); i++)
+            outputSet.insert( std::string(AiArrayGetStr(outputs, i)));
+
         ///////////////////////////////////////////////
         //      Create filters and outputs as needed 
         for (int i=0; i<this->globals.aov_depth; i++) {
@@ -1170,29 +1177,27 @@ private:
             strcat(filter_rank_name, rank_number_string );
             strcat(aov_rank_name, rank_number_string );
             
-            if ( AiNodeLookUpByName( filter_rank_name ) == NULL) {
+            const bool nofilter = AiNodeLookUpByName( filter_rank_name ) == NULL;
+            if ( nofilter ) {
                 AtNode *filter = AiNode("cryptomatte_filter");
                 AiNodeSetStr(filter, "name", filter_rank_name);
                 AiNodeSetInt(filter, "rank", i*2);
                 AiNodeSetStr(filter, "filter", aFilter_filter);
                 AiNodeSetFlt(filter, "width", aFilter_width);
                 AiNodeSetStr(filter, "mode", "double_rgba");
+            }
 
+            std::string new_output_str(aov_rank_name);
+            new_output_str += " " ;
+            new_output_str += "VECTOR" ;
+            new_output_str += " " ;
+            new_output_str += filter_rank_name ;
+            new_output_str += " " ;
+            new_output_str += AiNodeGetName(driver);
+
+            if (outputSet.find(new_output_str) == outputSet.end()) {
                 AiAOVRegister(aov_rank_name, AI_TYPE_VECTOR, AI_AOV_BLEND_NONE);
-
-                // Add an output to the render globals, or make a list of outputs to add, and register an AOV
-                char new_output_string[MAX_STRING_LENGTH * 8];
-                memset(new_output_string, 0, sizeof(new_output_string));
-
-                strcat(new_output_string, aov_rank_name );
-                strcat(new_output_string, " " );
-                strcat(new_output_string, "VECTOR" );
-                strcat(new_output_string, " " );
-                strcat(new_output_string, filter_rank_name );
-                strcat(new_output_string, " " );
-                strcat(new_output_string, AiNodeGetName(driver));
-
-                AiArraySetStr(tmp_new_outputs, output_offset + new_ouputs, new_output_string);
+                AiArraySetStr(tmp_new_outputs, output_offset + new_ouputs, new_output_str.c_str());
                 new_ouputs++;
             }
             AiArraySetStr(cryptoAOVs, i, aov_rank_name);
@@ -1212,7 +1217,7 @@ private:
         if (this->aovArray_cryptomaterial)
             AiArrayDestroy(this->aovArray_cryptomaterial);
         if (this->user_cryptomatte_info) {
-            for (AtUInt32 i=0; i<this->user_cryptomatte_info->nelements; i++) {
+            for (uint32_t i=0; i<AiArrayGetNumElements(this->user_cryptomatte_info); i++) {
                 AtArray *subarray = AiArrayGetArray(this->user_cryptomatte_info, i);
                 AiArraySetArray(this->user_cryptomatte_info, i, NULL);
                 if (subarray)

--- a/cryptomatte/cryptomatte.h
+++ b/cryptomatte/cryptomatte.h
@@ -870,10 +870,10 @@ public:
         init_cryptomatte_cache();
     }
 
-    void setup_all(const char* aov_cryptoasset, const char* aov_cryptoobject, const char* aov_cryptomaterial) {
-        this->aov_cryptoasset = AtString(aov_cryptoasset);
-        this->aov_cryptoobject = AtString(aov_cryptoobject);
-        this->aov_cryptomaterial = AtString(aov_cryptomaterial);
+    void setup_all(const AtString aov_cryptoasset, const AtString aov_cryptoobject, const AtString aov_cryptomaterial) {
+        this->aov_cryptoasset = aov_cryptoasset;
+        this->aov_cryptoobject = aov_cryptoobject;
+        this->aov_cryptomaterial = aov_cryptomaterial;
 
         this->destroy_arrays();
 

--- a/cryptomatte/cryptomatte_filter.cpp
+++ b/cryptomatte/cryptomatte_filter.cpp
@@ -9,7 +9,7 @@
 
 ///////////////////////////////////////////////
 //
-//		Filter node things
+//    Filter node things
 //
 ///////////////////////////////////////////////
 
@@ -18,10 +18,10 @@ AI_FILTER_NODE_EXPORT_METHODS(cryptomatte_filterMtd)
 
 
 enum cryptomatte_filterParams {
-	p_width,
-	p_rank,
-	p_filter,
-	p_mode,
+   p_width,
+   p_rank,
+   p_filter,
+   p_mode,
 };
 
 struct CryptomatteFilterData {
@@ -31,41 +31,41 @@ struct CryptomatteFilterData {
 };
 
 enum modeEnum {
-	p_mode_double_rgba,
+   p_mode_double_rgba,
 };
 
 static const char* modeEnumNames[] = {
-	"double_rgba",
-	NULL
+   "double_rgba",
+   NULL
 };
 
 node_parameters {
-	AiMetaDataSetStr(nentry, NULL, "maya.attr_prefix", "filter_");
-	AiMetaDataSetStr(nentry, NULL, "maya.translator", "cryptomatteFilter");
-	AiMetaDataSetInt(nentry, NULL, "maya.id", 0x00116420);
+   AiMetaDataSetStr(nentry, NULL, "maya.attr_prefix", "filter_");
+   AiMetaDataSetStr(nentry, NULL, "maya.translator", "cryptomatteFilter");
+   AiMetaDataSetInt(nentry, NULL, "maya.id", 0x00116420);
 
-	AiParameterFlt("width", 2.0);
-	AiParameterInt("rank", 0);
-	AiParameterEnum("filter", p_filter_gaussian, filterEnumNames);
-	AiParameterEnum("mode", p_mode_double_rgba, modeEnumNames);
+   AiParameterFlt("width", 2.0);
+   AiParameterInt("rank", 0);
+   AiParameterEnum("filter", p_filter_gaussian, filterEnumNames);
+   AiParameterEnum("mode", p_mode_double_rgba, modeEnumNames);
 }
 
 node_loader {
-	if (i>0) return 0;
-	node->methods     = cryptomatte_filterMtd;
-	node->output_type = AI_TYPE_RGBA;
-	node->name        = "cryptomatte_filter";
-	node->node_type   = AI_NODE_FILTER;
-	strcpy(node->version, AI_VERSION);
-	return true;
+   if (i>0) return 0;
+   node->methods     = cryptomatte_filterMtd;
+   node->output_type = AI_TYPE_RGBA;
+   node->name        = "cryptomatte_filter";
+   node->node_type   = AI_NODE_FILTER;
+   strcpy(node->version, AI_VERSION);
+   return true;
 }
 
 node_initialize {
-	// Z is still required despite the values themselves not being used. 
-	static const char* necessary_aovs[] = {
-		"FLOAT Z", 
-		NULL 
-	};
+   // Z is still required despite the values themselves not being used. 
+   static const char* necessary_aovs[] = {
+      "FLOAT Z", 
+      NULL 
+   };
     CryptomatteFilterData * data = new CryptomatteFilterData();
     AiNodeSetLocalData(node, data);
     AiFilterInitialize(node, true, necessary_aovs);
@@ -78,43 +78,43 @@ node_finish {
 }
 
 node_update {
-	AtShaderGlobals shader_globals;
-	AtShaderGlobals *sg = &shader_globals;
+   AtShaderGlobals shader_globals;
+   AtShaderGlobals *sg = &shader_globals;
 
     CryptomatteFilterData * data = (CryptomatteFilterData*) AiNodeGetLocalData(node);
     data->width = AiNodeGetFlt(node, "width");
     data->rank = AiNodeGetInt(node, "rank");
     data->filter = AiNodeGetInt(node, "filter");
-	if (data->filter == p_filter_box) {
-		AiFilterUpdate(node, 1.0f);
-	} else {
-		AiFilterUpdate(node, data->width);
-	}
+   if (data->filter == p_filter_box) {
+      AiFilterUpdate(node, 1.0f);
+   } else {
+      AiFilterUpdate(node, data->width);
+   }
     
 }
 
 filter_output_type {
-	if (input_type == AI_TYPE_VECTOR)
-		return AI_TYPE_RGBA;
-	else
-		return AI_TYPE_NONE;
+   if (input_type == AI_TYPE_VECTOR)
+      return AI_TYPE_RGBA;
+   else
+      return AI_TYPE_NONE;
 }
 
 
 ///////////////////////////////////////////////
 //
-//		Sample-Weight map Class and type definitions
+//    Sample-Weight map Class and type definitions
 //
 ///////////////////////////////////////////////
 
 class compareTail {
 public:
-	bool operator()(const std::pair<float, float> x, const std::pair<float, float> y) {
-		return x.second > y.second;
-	}
+   bool operator()(const std::pair<float, float> x, const std::pair<float, float> y) {
+      return x.second > y.second;
+   }
 };
 
-typedef std::map<float,float> 			sw_map_type ;
+typedef std::map<float,float>           sw_map_type ;
 typedef std::map<float,float>::iterator sw_map_iterator_type;
 
 void write_to_samples_map(sw_map_type * vals, float hash, float sample_weight) {
@@ -123,195 +123,195 @@ void write_to_samples_map(sw_map_type * vals, float hash, float sample_weight) {
 
 ///////////////////////////////////////////////
 //
-//		Filter proper
+//    Filter proper
 //
 ///////////////////////////////////////////////
 
-filter_pixel {	
-	AtShaderGlobals shader_globals;
-	AtShaderGlobals *sg = &shader_globals;
-	AtRGBA *out_value = (AtRGBA *)data_out;
-	*out_value = AI_RGBA_ZERO;
+filter_pixel { 
+   AtShaderGlobals shader_globals;
+   AtShaderGlobals *sg = &shader_globals;
+   AtRGBA *out_value = (AtRGBA *)data_out;
+   *out_value = AI_RGBA_ZERO;
     
     CryptomatteFilterData * data = (CryptomatteFilterData*)AiNodeGetLocalData(node);
 
-	AtNode * renderOptions = AiUniverseGetOptions();
-	int auto_transparency_depth = AiNodeGetInt(renderOptions, "auto_transparency_depth");
+   AtNode * renderOptions = AiUniverseGetOptions();
+   int auto_transparency_depth = AiNodeGetInt(renderOptions, "auto_transparency_depth");
 
-	AtNode * camera = AiUniverseGetCamera();
-	float camera_far_clip = AiNodeGetFlt(camera, "far_clip");
-	
-	float (*filter)(AtVector2, float);
-
-
-	///////////////////////////////////////////////
-	//
-	//		early out for black pixels
-	//
-	///////////////////////////////////////////////
-	
-	bool early_out = true;
-
-	while (AiAOVSampleIteratorGetNext(iterator)) {
-
-		if (AiAOVSampleIteratorHasValue(iterator))	{
-			early_out = false;	
-			break;
-		}
-
-	}
-
-	if (early_out) {
-		*out_value = AI_RGBA_ZERO;
-		if (data->rank == 0) {
-			out_value->g = 1.0f;					
-		}
-		return;
-	}
-	AiAOVSampleIteratorReset(iterator);
+   AtNode * camera = AiUniverseGetCamera();
+   float camera_far_clip = AiNodeGetFlt(camera, "far_clip");
+   
+   float (*filter)(AtVector2, float);
 
 
-	///////////////////////////////////////////////
-	//
-	//		Select Filter
-	//
-	///////////////////////////////////////////////
+   ///////////////////////////////////////////////
+   //
+   //    early out for black pixels
+   //
+   ///////////////////////////////////////////////
+   
+   bool early_out = true;
 
-	switch (data->filter) {
-		case p_filter_triangle:
-			filter = &triangle;
-			break;
-		case p_filter_blackman_harris:
-			filter = &blackman_harris;
-			break;
-		case p_filter_box:
-			filter = &box;
-			break;
-		case p_filter_disk:
-			filter = &disk;
-			break;
-		case p_filter_cone:
-			filter = &cone;
-			break;
-		case p_filter_gaussian:
-		default:
-			filter = &gaussian;
-			break;
-	}
+   while (AiAOVSampleIteratorGetNext(iterator)) {
+
+      if (AiAOVSampleIteratorHasValue(iterator))   {
+         early_out = false;   
+         break;
+      }
+
+   }
+
+   if (early_out) {
+      *out_value = AI_RGBA_ZERO;
+      if (data->rank == 0) {
+         out_value->g = 1.0f;             
+      }
+      return;
+   }
+   AiAOVSampleIteratorReset(iterator);
 
 
-	///////////////////////////////////////////////
-	//
-	//		Set up sample-weight maps and friends
-	//
-	///////////////////////////////////////////////
+   ///////////////////////////////////////////////
+   //
+   //    Select Filter
+   //
+   ///////////////////////////////////////////////
 
-	sw_map_type vals;
-
-
-	int total_samples = 0;
-	float total_weight = 0.0f;
-	float sample_weight;
-	AtVector2 offset;
-	static const AtString zAOV("Z");
-
-	///////////////////////////////////////////////
-	//
-	//		Iterate samples
-	//
-	///////////////////////////////////////////////
-	while (AiAOVSampleIteratorGetNext(iterator)) {
-		offset = AiAOVSampleIteratorGetOffset(iterator);
-		sample_weight = filter(offset, data->width);
-
-		if (sample_weight == 0.0f) {
-			continue;
-		}
-		total_samples++;
-
-		///////////////////////////////////////////////
-		//
-		//		Samples with no value.
-		//
-		///////////////////////////////////////////////
-
-		if (!AiAOVSampleIteratorHasValue(iterator))	{			
-			total_weight += sample_weight;
-			write_to_samples_map(&vals, 0.0f, sample_weight);
-			continue;
-		}
+   switch (data->filter) {
+      case p_filter_triangle:
+         filter = &triangle;
+         break;
+      case p_filter_blackman_harris:
+         filter = &blackman_harris;
+         break;
+      case p_filter_box:
+         filter = &box;
+         break;
+      case p_filter_disk:
+         filter = &disk;
+         break;
+      case p_filter_cone:
+         filter = &cone;
+         break;
+      case p_filter_gaussian:
+      default:
+         filter = &gaussian;
+         break;
+   }
 
 
-		///////////////////////////////////////////////
-		//
-		//		Samples with values, depth or no depth
-		//
-		///////////////////////////////////////////////
-		
-		float quota = sample_weight;
-		float iterative_transparency_weight = 1.0f;
-		int depth = 0;
-		AtVector sample_value = AI_V3_ZERO;
+   ///////////////////////////////////////////////
+   //
+   //    Set up sample-weight maps and friends
+   //
+   ///////////////////////////////////////////////
 
-		total_weight += quota;
-		while (AiAOVSampleIteratorGetNextDepth(iterator)) {
-			// sample.x is the ID
-			// sample.y is unused
-			// sample.z is the opacity
-			sample_value = AiAOVSampleIteratorGetVec(iterator);
-			const float sub_sample_opacity = sample_value.z;
-			const float sub_sample_weight = sub_sample_opacity * iterative_transparency_weight * sample_weight;
-
-			// so if the current sub sample is 80% opaque, it means 20% of the weight will remain for the next subsample
-			iterative_transparency_weight *= (1.0f - sub_sample_opacity); 
-
-			quota -= sub_sample_weight;
-			write_to_samples_map(&vals, sample_value.x, sub_sample_weight);
-		}
-		
-		if (quota != 0.0) {
-			// the remaining values gets allocated to the last sample 
-			write_to_samples_map(&vals, sample_value.x, quota);
-		}
-	}
+   sw_map_type vals;
 
 
-	///////////////////////////////////////////////
-	//
-	//		Rank samples and make pixels
-	//
-	///////////////////////////////////////////////
+   int total_samples = 0;
+   float total_weight = 0.0f;
+   float sample_weight;
+   AtVector2 offset;
+   static const AtString zAOV("Z");
 
-	if (total_samples == 0) {
-		return;
-	}
+   ///////////////////////////////////////////////
+   //
+   //    Iterate samples
+   //
+   ///////////////////////////////////////////////
+   while (AiAOVSampleIteratorGetNext(iterator)) {
+      offset = AiAOVSampleIteratorGetOffset(iterator);
+      sample_weight = filter(offset, data->width);
 
-	sw_map_iterator_type vals_iter;
-	
-	std::vector<std::pair<float, float> > all_vals;
-	std::vector<std::pair<float, float> >::iterator all_vals_iter;
+      if (sample_weight == 0.0f) {
+         continue;
+      }
+      total_samples++;
 
-	for (vals_iter = vals.begin(); vals_iter != vals.end(); ++vals_iter) {
-		all_vals.push_back(*vals_iter);
-	}
-	
-	std::sort(all_vals.begin(), all_vals.end(), compareTail());
+      ///////////////////////////////////////////////
+      //
+      //    Samples with no value.
+      //
+      ///////////////////////////////////////////////
+
+      if (!AiAOVSampleIteratorHasValue(iterator))  {        
+         total_weight += sample_weight;
+         write_to_samples_map(&vals, 0.0f, sample_weight);
+         continue;
+      }
 
 
-	int iter = 0;
-	for (all_vals_iter = all_vals.begin(); all_vals_iter != all_vals.end(); ++all_vals_iter) {
-		if (iter == data->rank) {
-			out_value->r = all_vals_iter->first;
-			out_value->g = (all_vals_iter->second / total_weight);
-		}
-		else if (iter == data->rank + 1) {
-			out_value->b = all_vals_iter->first;
-			out_value->a = (all_vals_iter->second / total_weight);
-			return;
-		}
+      ///////////////////////////////////////////////
+      //
+      //    Samples with values, depth or no depth
+      //
+      ///////////////////////////////////////////////
+      
+      float quota = sample_weight;
+      float iterative_transparency_weight = 1.0f;
+      int depth = 0;
+      AtVector sample_value = AI_V3_ZERO;
 
-		iter++;
-	}
+      total_weight += quota;
+      while (AiAOVSampleIteratorGetNextDepth(iterator)) {
+         // sample.x is the ID
+         // sample.y is unused
+         // sample.z is the opacity
+         sample_value = AiAOVSampleIteratorGetVec(iterator);
+         const float sub_sample_opacity = sample_value.z;
+         const float sub_sample_weight = sub_sample_opacity * iterative_transparency_weight * sample_weight;
+
+         // so if the current sub sample is 80% opaque, it means 20% of the weight will remain for the next subsample
+         iterative_transparency_weight *= (1.0f - sub_sample_opacity); 
+
+         quota -= sub_sample_weight;
+         write_to_samples_map(&vals, sample_value.x, sub_sample_weight);
+      }
+      
+      if (quota != 0.0) {
+         // the remaining values gets allocated to the last sample 
+         write_to_samples_map(&vals, sample_value.x, quota);
+      }
+   }
+
+
+   ///////////////////////////////////////////////
+   //
+   //    Rank samples and make pixels
+   //
+   ///////////////////////////////////////////////
+
+   if (total_samples == 0) {
+      return;
+   }
+
+   sw_map_iterator_type vals_iter;
+   
+   std::vector<std::pair<float, float> > all_vals;
+   std::vector<std::pair<float, float> >::iterator all_vals_iter;
+
+   for (vals_iter = vals.begin(); vals_iter != vals.end(); ++vals_iter) {
+      all_vals.push_back(*vals_iter);
+   }
+   
+   std::sort(all_vals.begin(), all_vals.end(), compareTail());
+
+
+   int iter = 0;
+   for (all_vals_iter = all_vals.begin(); all_vals_iter != all_vals.end(); ++all_vals_iter) {
+      if (iter == data->rank) {
+         out_value->r = all_vals_iter->first;
+         out_value->g = (all_vals_iter->second / total_weight);
+      }
+      else if (iter == data->rank + 1) {
+         out_value->b = all_vals_iter->first;
+         out_value->a = (all_vals_iter->second / total_weight);
+         return;
+      }
+
+      iter++;
+   }
 }
 
 

--- a/cryptomatte/cryptomatte_filter.cpp
+++ b/cryptomatte/cryptomatte_filter.cpp
@@ -114,10 +114,10 @@ public:
    }
 };
 
-typedef std::map<float,float>           sw_map_type ;
-typedef std::map<float,float>::iterator sw_map_iterator_type;
+typedef std::map<float,float>           sw_map_t ;
+typedef std::map<float,float>::iterator sw_map_iterator_t;
 
-void write_to_samples_map(sw_map_type * vals, float hash, float sample_weight) {
+void write_to_samples_map(sw_map_t * vals, float hash, float sample_weight) {
    (*vals)[hash] += sample_weight;
 }
 
@@ -206,7 +206,7 @@ filter_pixel {
    //
    ///////////////////////////////////////////////
 
-   sw_map_type vals;
+   sw_map_t vals;
 
 
    int total_samples = 0;
@@ -286,7 +286,7 @@ filter_pixel {
       return;
    }
 
-   sw_map_iterator_type vals_iter;
+   sw_map_iterator_t vals_iter;
    
    std::vector<std::pair<float, float> > all_vals;
    std::vector<std::pair<float, float> >::iterator all_vals_iter;

--- a/cryptomatte/filters.h
+++ b/cryptomatte/filters.h
@@ -27,12 +27,21 @@ static const char* filterEnumNames[] =
 };
 
 
-float gaussian(AtPoint2 p, float width) {
+float gaussian(AtVector2 p, float width) {
+	/* matches Arnold's exactly. */
+		/* Sharpness=2 is good for width 2, sigma=1/sqrt(8) for the width=4,sharpness=4 case */
+	// const float sigma = 0.5f;
+	// const float sharpness = 1.0f / (2.0f * sigma * sigma);
+
 	p /= (width * 0.5f);
 	float dist_squared = (p.x * p.x + p.y * p.y) ;
 	if (dist_squared >  (1.0f)) {
 		return 0.0f;
 	}
+
+	// const float normalization_factor = 1;
+	// Float weight = normalization_factor * expf(-dist_squared * sharpness);
+
 	float weight = expf(-dist_squared * 2.0f); // was: 
 
 	if (weight > 0.0f) {
@@ -43,7 +52,7 @@ float gaussian(AtPoint2 p, float width) {
 }
 
 
-float blackman_harris(AtPoint2 p, float width) {
+float blackman_harris(AtVector2 p, float width) {
 	// Close to matching Arnolds, but not exact. 
 	p /= (width * 0.5f);
 
@@ -64,12 +73,12 @@ float blackman_harris(AtPoint2 p, float width) {
 }
 
 
-float box(AtPoint2 p, float width) {
+float box(AtVector2 p, float width) {
 	// The trick with matching arnold's filter here is making sure you give a value of 1.0 in the filter update . 
 	return 1.0f;
 }
 
-float box_strict(AtPoint2 p, float width) {
+float box_strict(AtVector2 p, float width) {
 	// The trick with matching arnold's filter here is making sure you give a value of 1.0 in the filter update.
 	if (std::abs(p.x) > 1.0 || std::abs(p.y) > 1.0)
 		return 1.0f;
@@ -78,7 +87,7 @@ float box_strict(AtPoint2 p, float width) {
 }
 
 
-float triangle(AtPoint2 p, float width) {
+float triangle(AtVector2 p, float width) {
 	// Still does not match arnold's
 	p /= (width * 0.5f);
 	float weight = std::abs(p.x) + std::abs(p.y);
@@ -86,7 +95,7 @@ float triangle(AtPoint2 p, float width) {
 }
 
 
-float disk(AtPoint2 p, float width) {
+float disk(AtVector2 p, float width) {
 	// Is now extremely close to arnold's
 
 	p /= (width * 0.5f);
@@ -99,7 +108,7 @@ float disk(AtPoint2 p, float width) {
 }
 
 
-float cone(AtPoint2 p, float width) {
+float cone(AtVector2 p, float width) {
 	// Is now extremely close to arnold's
 
 	p /= (width * 0.5f);

--- a/cryptomatte/filters.h
+++ b/cryptomatte/filters.h
@@ -7,117 +7,117 @@
 
 enum filterEnum
 {
-	p_filter_gaussian=0,
-	p_filter_blackman_harris,
-	p_filter_triangle,
-	p_filter_box,
-	p_filter_disk,
-	p_filter_cone
+   p_filter_gaussian=0,
+   p_filter_blackman_harris,
+   p_filter_triangle,
+   p_filter_box,
+   p_filter_disk,
+   p_filter_cone
 };
 
 static const char* filterEnumNames[] =
 {
-	"gaussian",
-	"blackman_harris",
-	"triangle",
-	"box",
-	"disk",
-	"cone",
-	NULL
+   "gaussian",
+   "blackman_harris",
+   "triangle",
+   "box",
+   "disk",
+   "cone",
+   NULL
 };
 
 
 float gaussian(AtVector2 p, float width) {
-	/* matches Arnold's exactly. */
-		/* Sharpness=2 is good for width 2, sigma=1/sqrt(8) for the width=4,sharpness=4 case */
-	// const float sigma = 0.5f;
-	// const float sharpness = 1.0f / (2.0f * sigma * sigma);
+   /* matches Arnold's exactly. */
+      /* Sharpness=2 is good for width 2, sigma=1/sqrt(8) for the width=4,sharpness=4 case */
+   // const float sigma = 0.5f;
+   // const float sharpness = 1.0f / (2.0f * sigma * sigma);
 
-	p /= (width * 0.5f);
-	float dist_squared = (p.x * p.x + p.y * p.y) ;
-	if (dist_squared >  (1.0f)) {
-		return 0.0f;
-	}
+   p /= (width * 0.5f);
+   float dist_squared = (p.x * p.x + p.y * p.y) ;
+   if (dist_squared >  (1.0f)) {
+      return 0.0f;
+   }
 
-	// const float normalization_factor = 1;
-	// Float weight = normalization_factor * expf(-dist_squared * sharpness);
+   // const float normalization_factor = 1;
+   // Float weight = normalization_factor * expf(-dist_squared * sharpness);
 
-	float weight = expf(-dist_squared * 2.0f); // was: 
+   float weight = expf(-dist_squared * 2.0f); // was: 
 
-	if (weight > 0.0f) {
-		return weight;
-	} else {
-		return 0.0f;
-	}
+   if (weight > 0.0f) {
+      return weight;
+   } else {
+      return 0.0f;
+   }
 }
 
 
 float blackman_harris(AtVector2 p, float width) {
-	// Close to matching Arnolds, but not exact. 
-	p /= (width * 0.5f);
+   // Close to matching Arnolds, but not exact. 
+   p /= (width * 0.5f);
 
-	float dist_squared = (p.x * p.x + p.y * p.y) ;
-	if (dist_squared >=  (1.0f)) {
-		return 0.0f;
-	}
-	float x = sqrt(dist_squared);
+   float dist_squared = (p.x * p.x + p.y * p.y) ;
+   if (dist_squared >=  (1.0f)) {
+      return 0.0f;
+   }
+   float x = sqrt(dist_squared);
 
-	float a0 = 0.35875f;
-	float a1 = 0.48829f;
-	float a2 = 0.14128f;
-	float a3 = 0.01168f;
+   float a0 = 0.35875f;
+   float a1 = 0.48829f;
+   float a2 = 0.14128f;
+   float a3 = 0.01168f;
 
-	float weight  = a0 + a1*cos(1.0f * AI_PI * x) + a2*cos(2.0f * AI_PI * x) + a3*cos(4.0f * AI_PI * x);
+   float weight  = a0 + a1*cos(1.0f * AI_PI * x) + a2*cos(2.0f * AI_PI * x) + a3*cos(4.0f * AI_PI * x);
 
-	return weight;
+   return weight;
 }
 
 
 float box(AtVector2 p, float width) {
-	// The trick with matching arnold's filter here is making sure you give a value of 1.0 in the filter update . 
-	return 1.0f;
+   // The trick with matching arnold's filter here is making sure you give a value of 1.0 in the filter update . 
+   return 1.0f;
 }
 
 float box_strict(AtVector2 p, float width) {
-	// The trick with matching arnold's filter here is making sure you give a value of 1.0 in the filter update.
-	if (std::abs(p.x) > 1.0 || std::abs(p.y) > 1.0)
-		return 1.0f;
-	else
-		return 0.0f;
+   // The trick with matching arnold's filter here is making sure you give a value of 1.0 in the filter update.
+   if (std::abs(p.x) > 1.0 || std::abs(p.y) > 1.0)
+      return 1.0f;
+   else
+      return 0.0f;
 }
 
 
 float triangle(AtVector2 p, float width) {
-	// Still does not match arnold's
-	p /= (width * 0.5f);
-	float weight = std::abs(p.x) + std::abs(p.y);
-	return 2.0f - weight;
+   // Still does not match arnold's
+   p /= (width * 0.5f);
+   float weight = std::abs(p.x) + std::abs(p.y);
+   return 2.0f - weight;
 }
 
 
 float disk(AtVector2 p, float width) {
-	// Is now extremely close to arnold's
+   // Is now extremely close to arnold's
 
-	p /= (width * 0.5f);
-	float dist_squared = (p.x * p.x + p.y * p.y) ;
-	if (dist_squared > (1.0f)) {
-		return 0.0f;
-	} else {
-		return 1.0f;
-	}
+   p /= (width * 0.5f);
+   float dist_squared = (p.x * p.x + p.y * p.y) ;
+   if (dist_squared > (1.0f)) {
+      return 0.0f;
+   } else {
+      return 1.0f;
+   }
 }
 
 
 float cone(AtVector2 p, float width) {
-	// Is now extremely close to arnold's
+   // Is now extremely close to arnold's
 
-	p /= (width * 0.5f);
-	float distance = sqrt(p.x * p.x + p.y * p.y) ;
-	if (distance > (1.0f)) {
-		return 0.0f;
-	} else {
-		return 1.0f - distance;
-	}
+   p /= (width * 0.5f);
+   float distance = sqrt(p.x * p.x + p.y * p.y) ;
+   if (distance > (1.0f)) {
+      return 0.0f;
+   } else {
+      return 1.0f - distance;
+   }
 
 }
 


### PR DESCRIPTION
This updates Cryptomatte to Arnold 5 and does some formatting changes. I've tested transparency and regular usage and it seems to work. I've only tested Maya and haven't tested the user data driven ones yet, but there's no reason to suspect those wouldn't work. 

There's another rough spot right now where the pass through shader is required to compute the opacity in the closures, which should probably be handled by cryptomatte.h, but this is perfectly functional for testing. I'd also like to get Solid Angle's eyes on how I'm doing the opacity computation. I don't know how expensive that is or whether that work could be skipped if the opacity flag is off, and whether this would be a good idea from a performance standpoint. 