### PR TITLE
Based on the arnold API rules and to support gcc versions older than …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,9 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS 1)
 
 set(CMAKE_CXX_STANDARD 11)
 
+# Statically link stdc++ to avoid GLILBC version clashes
+set(CMAKE_SHARED_LINKER_FLAGS "-static-libstdc++")
+
 # Compiler flags
 if (${CMAKE_SYSTEM_NAME} MATCHES "Windows")
     # Disable some of the bullshit warnings MSVC wants to barf

--- a/cryptomatte/cryptomatte_shader.cpp
+++ b/cryptomatte/cryptomatte_shader.cpp
@@ -65,11 +65,11 @@ node_update
                                                   AiNodeGetBool(node, "strip_mat_namespaces"));
 
    AtArray* uc_aov_array = AiArray(4, 1, AI_TYPE_STRING, 
-      AiNodeGetStr(node, "user_crypto_aov_0"), AiNodeGetStr(node, "user_crypto_aov_1"), 
-      AiNodeGetStr(node, "user_crypto_aov_2"), AiNodeGetStr(node, "user_crypto_aov_3"));
+      AiNodeGetStr(node, "user_crypto_aov_0").c_str(), AiNodeGetStr(node, "user_crypto_aov_1").c_str(), 
+      AiNodeGetStr(node, "user_crypto_aov_2").c_str(), AiNodeGetStr(node, "user_crypto_aov_3").c_str());
    AtArray* uc_src_array = AiArray(4, 1, AI_TYPE_STRING, 
-      AiNodeGetStr(node, "user_crypto_src_0"), AiNodeGetStr(node, "user_crypto_src_1"), 
-      AiNodeGetStr(node, "user_crypto_src_2"), AiNodeGetStr(node, "user_crypto_src_3"));
+      AiNodeGetStr(node, "user_crypto_src_0").c_str(), AiNodeGetStr(node, "user_crypto_src_1").c_str(), 
+      AiNodeGetStr(node, "user_crypto_src_2").c_str(), AiNodeGetStr(node, "user_crypto_src_3").c_str());
    
    CryptomatteData_setup_all(data, AiNodeGetStr(node, "aov_crypto_asset"),
                           AiNodeGetStr(node, "aov_crypto_object"),


### PR DESCRIPTION
…4.8.x, the returns from AiNodeGetStr() have been explicitly converted using the built-in c_str() method. Also changed the cmake file to statically link the stdc++ lib as that can be a potential problem on older gcc versions. More details can be found on this issue ticket - https://github.com/anderslanglands/alShaders2/issues/4