### PR TITLE
Fix crash with multiple cryptomattes and parallel node init

### DIFF
--- a/cryptomatte/cryptomatte.cpp
+++ b/cryptomatte/cryptomatte.cpp
@@ -2,6 +2,8 @@
 #include "MurmurHash3.h"
 #include <ai.h>
 
+AtCritSec g_critsec;
+
 // User data names
 const AtString CRYPTO_ASSET_UDATA("crypto_asset");
 const AtString CRYPTO_OBJECT_UDATA("crypto_object");

--- a/tests/cryptomatte/000_mtoa_basic.ass
+++ b/tests/cryptomatte/000_mtoa_basic.ass
@@ -43,6 +43,11 @@ cryptomatte
  run_unit_tests true
 }
 
+cryptomatte
+{
+ name ADDITIONAL_CRYPTOMATTE_TO_TEST_PARALLEL_ISSUES
+}
+
 gaussian_filter
 {
  name defaultArnoldFilter@gaussian_filter

--- a/tests/cryptomatte/002_multicam.ass
+++ b/tests/cryptomatte/002_multicam.ass
@@ -171,6 +171,14 @@ cryptomatte
  user_crypto_src_0 "special_chars_udata"
 }
 
+cryptomatte
+{
+ name ADDITIONAL_CRYPTOMATTE_TO_TEST_PARALLEL_ISSUES
+ user_crypto_aov_0 "other_aov"
+ user_crypto_src_0 "other_aov_udata"
+}
+
+
 gaussian_filter
 {
  name defaultArnoldFilter@gaussian_filter

--- a/tests/cryptomatte_tests.py
+++ b/tests/cryptomatte_tests.py
@@ -370,6 +370,7 @@ class Cryptomatte002(CryptomatteTestBase):
         Multicamera renders with embedded manifests
     """
     ass = "cryptomatte/002_multicam.ass"
+    arnold_t = 0
 
     def test_compression_and_manifests(self):
         self.assertAllManifestsValidAndMatch()

--- a/tests/cryptomatte_tests.py
+++ b/tests/cryptomatte_tests.py
@@ -320,6 +320,7 @@ class Cryptomatte000(CryptomatteTestBase):
     """
     ass = "cryptomatte/000_mtoa_basic.ass"
     arnold_v = 6
+    arnold_t = 0
 
     def test_compression_and_manifests(self):
         self.assertAllManifestsValidAndMatch()


### PR DESCRIPTION
Fixes the issue reported in #30, adds tests for it. Having multiple Cryptomattes is still not recommended, certain things like sidecar manifests can break as a result. 